### PR TITLE
Add new blog post to content section

### DIFF
--- a/data/sections.yml
+++ b/data/sections.yml
@@ -31,6 +31,7 @@
     - [Confidence in software](https://www.theguild.nl/confidence-in-your-software/){:target='_blank'} (English)
     - [Vertrouwen in software](https://blog.kabisa.nl/vertrouwen-in-software/){:target='_blank'} (Dutch)
     - [Does your test tell a story?](https://www.theguild.nl/does-your-test-tell-a-story/){:target='_blank'}
+    - [5 reasons not to use safe navigation operators](https://www.theguild.nl/5-reasons-not-to-use-safe-navigation-operators/){:target='_blank'}
 - title: Contact
   icon: chat
   content: Feel free to __contact__ or visit me online


### PR DESCRIPTION
Add a link to the [5 reasons not to use safe navigation operators](https://www.theguild.nl/5-reasons-not-to-use-safe-navigation-operators/) blog post to the content section of the homepage